### PR TITLE
PR: fill() types and backfilling

### DIFF
--- a/content/influxdb/v0.9/clients/api.md
+++ b/content/influxdb/v0.9/clients/api.md
@@ -29,6 +29,7 @@ This is a list of the client libraries which have some support for InfluxDB vers
 
 ## .Net
 - [InfluxDB.Client.Net](https://github.com/AdysTech/InfluxDB.Client.Net) by [mvadu](https://github.com/mvadu)
+- [InfluxData.Net](https://github.com/pootzko/InfluxData.Net) by [pootzko](https://github.com/pootzko)
 
 
 ## Perfmon

--- a/content/influxdb/v0.9/query_language/continuous_queries.md
+++ b/content/influxdb/v0.9/query_language/continuous_queries.md
@@ -68,3 +68,41 @@ The drop query takes the following form:
 ```sql
 DROP CONTINUOUS QUERY <name> ON <database>
 ```
+
+## Backfilling
+
+Backfilling in InfluxDB 0.9 is not supported per se. Instead ad-hoc queries using `INTO` clause must be run. This is useful because it makes backfills more flexible and controlable - running them can now be restricted to short time ranges to prevent long lasting CPU spikes. Backfill queries do require a `WHERE` clause with a `time` restriction. Tags can be used optionally in the same way as in continuous queries.
+
+```sql
+SELECT min(temp) as min_temp, max(temp) as max_temp INTO "reading.minmax.5m" FROM reading 
+WHERE time >= '2015-12-14 00:05:20' AND time < '2015-12-15 00:05:20'
+GROUP BY time(5m)
+```
+
+Tags (`sensor_id` in the example bellow) can be used optionally in the same way as in continuous queries.
+
+```sql
+SELECT min(temp) as min_temp, max(temp) as max_temp INTO "reading.minmax.5m" FROM reading 
+WHERE time >= '2015-12-14 00:05:20' AND time < '2015-12-15 00:05:20'
+GROUP BY time(5m), sensor_id
+```
+
+To prevent the backfill from creating a huge number of "empty" points containing only `null` values, [fill()](/influxdb/v0.9/query_language/data_exploration/#the-group-by-clause-and-fill) can be used at the end of the query.
+
+```sql
+SELECT min(temp) as min_temp, max(temp) as max_temp INTO "reading.minmax.5m" FROM reading 
+WHERE time >= '2015-12-14 00:05:20' AND time < '2015-12-15 00:05:20'
+GROUP BY time(5m), fill(none)
+```
+
+If you would like to further break down the queries and run them with even more control, you can add additional `WHERE` clauses.
+
+```sql
+SELECT min(temp) as min_temp, max(temp) as max_temp INTO "reading.minmax.5m" FROM reading 
+WHERE sensor_id="EG-21442" AND time >= '2015-12-14 00:05:20' AND time < '2015-12-15 00:05:20'
+GROUP BY time(5m)
+```
+
+In InfluxDB 0.9, a point is uniquely identified by the measurement, full tag set, and timestamp. Re-backfilling or writing another point with the same measurement, tag set, and timestamp will silently overwrite the already existing point, it will not create a duplicate.
+
+

--- a/content/influxdb/v0.9/query_language/data_exploration.md
+++ b/content/influxdb/v0.9/query_language/data_exploration.md
@@ -296,9 +296,9 @@ Calculate the average `water_level` for the different tag values of `location` i
 By default, a `GROUP BY` interval with no data has `null` as its value in the output column. Use `fill()` to change the value reported for intervals that have no data. `fill()` options include:
 
 * Any numerical value
-* `null` - exhibits the same behavior as the default
-* `previous` - reports the value of the previous window
-* `none` - suppresses timestamps and values where the value is null
+* `null` - exhibits the same behavior as the default (sets `null` as value for interval with no data)
+* `previous` - reports the value of the previous time window (copies values from the previous interval)
+* `none` - suppresses timestamps and values where the value is null (interval record is skipped ant not shown at all)
 
 Follow the ✨ in the examples below to see what `fill()` can do.
 

--- a/content/influxdb/v0.9/query_language/data_exploration.md
+++ b/content/influxdb/v0.9/query_language/data_exploration.md
@@ -296,9 +296,9 @@ Calculate the average `water_level` for the different tag values of `location` i
 By default, a `GROUP BY` interval with no data has `null` as its value in the output column. Use `fill()` to change the value reported for intervals that have no data. `fill()` options include:
 
 * Any numerical value
-* `null` - exhibits the same behavior as the default (sets `null` as value for interval with no data)
-* `previous` - reports the value of the previous time window (copies values from the previous interval)
-* `none` - suppresses timestamps and values where the value is null (interval record is skipped ant not shown at all)
+* `null` - sets `null` as the value for intervals with no data
+* `previous` - copies the value from the previous interval for intervals with no data
+* `none` - skips intervals with no data to report
 
 Follow the ✨ in the examples below to see what `fill()` can do.
 


### PR DESCRIPTION
Added a bit more verbosity for `fill()` types and explained backfilling in InfluxDB v0.9.