### PR TITLE
Fix spelling of "GitHub"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 We welcome (and encourage!) contributions from the community.
 
 * [Install Hugo](http://gohugo.io/overview/installing/)
-* Fork this repository on Github
+* Fork this repository on GitHub
 * Clone the repo to your local computer
 ```bash
 git clone https://github.com/your_username/docs.influxdata.com.git

--- a/content/influxdb/v0.9/write_protocols/collectd.md
+++ b/content/influxdb/v0.9/write_protocols/collectd.md
@@ -6,4 +6,4 @@ menu:
     parent: write_protocols
 ---
 
-InfluxDB provides an easy way to hook up CollectD as an input source. See the [README on Github](https://github.com/influxdb/influxdb/blob/master/services/collectd/README.md) for more information.
+InfluxDB provides an easy way to hook up CollectD as an input source. See the [README on GitHub](https://github.com/influxdb/influxdb/blob/master/services/collectd/README.md) for more information.

--- a/content/influxdb/v0.9/write_protocols/graphite.md
+++ b/content/influxdb/v0.9/write_protocols/graphite.md
@@ -6,4 +6,4 @@ menu:
     parent: write_protocols
 ---
 
-InfluxDB provides an easy way to hook up Graphite as an input source. See the [README on Github](https://github.com/influxdb/influxdb/blob/master/services/graphite/README.md) for more information.
+InfluxDB provides an easy way to hook up Graphite as an input source. See the [README on GitHub](https://github.com/influxdb/influxdb/blob/master/services/graphite/README.md) for more information.

--- a/content/influxdb/v0.9/write_protocols/opentsdb.md
+++ b/content/influxdb/v0.9/write_protocols/opentsdb.md
@@ -6,4 +6,4 @@ menu:
     parent: write_protocols
 ---
 
-InfluxDB provides an easy way to hook up OpenTSDB as an input source. See the [README on Github](https://github.com/influxdb/influxdb/blob/master/services/opentsdb/README.md) for more information.
+InfluxDB provides an easy way to hook up OpenTSDB as an input source. See the [README on GitHub](https://github.com/influxdb/influxdb/blob/master/services/opentsdb/README.md) for more information.


### PR DESCRIPTION
I used:

    perl -i -pe 's/Github/GitHub/g' `git grep -l Github`